### PR TITLE
Add support to specify name/description/script/environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ nsm --start
 
 nsm requires root privileges on all platforms.
 
+## Change name/description/script/environment variables
+
+```
+nsm --install --name=anothername --script=src/server.js --env.NODE_ENV=production
+nsm --start
+```
+
+
 Example
 -------
 

--- a/nsm.js
+++ b/nsm.js
@@ -12,7 +12,7 @@ var argv = optimist
     .describe('restart', 'Restart a service')
     .argv;
 
-var service = Service.create();
+var service = Service.create(argv);
 
 if (argv.install)
     service.install();

--- a/service.js
+++ b/service.js
@@ -14,14 +14,22 @@ else if (platform === 'darwin')
 else
     throw new Error('Platform \'' + platform + '\' is not supported');
 
-Service.create = function () {
+Service.create = function (argv) {
     var package = require(path.join(process.cwd(), './package.json'));
 
-    var service = new Service({
-        name: package.name,
-        description: package.description,
-        script: package.main
+    var env = Object.keys(argv.env || {}).map(function (key) {
+        return { name: key, value: argv.env[key] };
     });
+
+    var options = {
+        name: argv.name || package.name,
+        description: argv.description || package.description,
+        script: argv.script || package.main,
+        logmode: argv.logmode,
+        env: env
+    };
+
+    var service = new Service(options);
 
     return service;
 };


### PR DESCRIPTION
It is useful when the app has more than one entry point (e.g. server and worker).
